### PR TITLE
Fix #6 the system attributes config were erased by the import system

### DIFF
--- a/ImportExport/Writer/AttributeWriter.php
+++ b/ImportExport/Writer/AttributeWriter.php
@@ -44,6 +44,11 @@ class AttributeWriter extends EntityFieldWriter
      */
     protected function setExtendData($className, $fieldName, $state)
     {
+        $provider = $this->configManager->getProvider('entity');
+        if ($provider->hasConfig($className, $fieldName)) {
+            return;
+        }
+
         $provider = $this->configManager->getProvider('extend');
         if (!$provider) {
             return;


### PR DESCRIPTION
Fix #6

The system attributes config were erased by the import system, as explained in orocommerce/orocommerce#13