### PR TITLE
Refactored attribute types list to a container parameter

### DIFF
--- a/DependencyInjection/SynoliaOroneoExtension.php
+++ b/DependencyInjection/SynoliaOroneoExtension.php
@@ -23,6 +23,7 @@ class SynoliaOroneoExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('parameters.yml');
         $loader->load('services.yml');
         $loader->load('import_export.yml');
         $loader->load('form_types.yml');

--- a/ImportExport/DataConverter/AttributeDataConverter.php
+++ b/ImportExport/DataConverter/AttributeDataConverter.php
@@ -16,7 +16,10 @@ class AttributeDataConverter extends EntityFieldDataConverter implements Context
 {
     use DataConverterTrait;
 
-    /** @var ConfigManager $entityConfigManager*/
+    /** @var string[] */
+    protected $attributeMapping;
+
+    /** @var ConfigManager */
     protected $entityConfigManager;
 
     /** @var null|EntityConfigModel */
@@ -26,22 +29,24 @@ class AttributeDataConverter extends EntityFieldDataConverter implements Context
     protected $context;
 
     /**
+     * AttributeDataConverter constructor.
+     *
+     * @param ConfigManager $entityConfigManager
+     * @param string[] $attributeMapping
+     */
+    public function __construct(ConfigManager $entityConfigManager, array $attributeMapping)
+    {
+        $this->entityConfigManager = $entityConfigManager;
+        $this->productConfigModel  = $entityConfigManager->getConfigEntityModel(Product::class);
+        $this->attributeMapping = $attributeMapping;
+    }
+
+    /**
      * @param ContextInterface $context
      */
     public function setImportExportContext(ContextInterface $context)
     {
         $this->context = $context;
-    }
-
-    /**
-     * AttributeDataConverter constructor.
-     *
-     * @param ConfigManager $entityConfigManager
-     */
-    public function __construct(ConfigManager $entityConfigManager)
-    {
-        $this->entityConfigManager = $entityConfigManager;
-        $this->productConfigModel  = $entityConfigManager->getConfigEntityModel(Product::class);
     }
 
     /**
@@ -56,10 +61,9 @@ class AttributeDataConverter extends EntityFieldDataConverter implements Context
 
         // Manage Akeneo field type. It is always under the form 'pim_catalog_TYPE'.
         if (isset($importedRecord['type'])) {
-            $type = explode('_', $importedRecord['type']);
             $akeneoTypes = $this->getAkeneoDataTypes();
-            if (array_key_exists(end($type), $akeneoTypes)) {
-                $importedRecord['type'] = $akeneoTypes[end($type)];
+            if (array_key_exists($importedRecord['type'], $akeneoTypes)) {
+                $importedRecord['type'] = $akeneoTypes[$importedRecord['type']];
             }
         }
 
@@ -100,18 +104,6 @@ class AttributeDataConverter extends EntityFieldDataConverter implements Context
      */
     protected function getAkeneoDataTypes()
     {
-        return [
-            'identifier'       => 'string',
-            'text'             => 'string',
-            'textarea'         => 'text',
-            'metric'           => 'decimal',
-            'boolean'          => 'boolean',
-            'simpleselect'     => 'enum',
-            'number'           => 'decimal',
-            'multiselect'      => 'multiEnum',
-            'date'             => 'date',
-            'image'            => 'image',
-            'file'             => 'file',
-        ];
+        return $this->attributeMapping;
     }
 }

--- a/Resources/config/import_export.yml
+++ b/Resources/config/import_export.yml
@@ -51,6 +51,7 @@ services:
         parent: oro_entity_config.importexport.data_converter.entity_field
         arguments:
             - '@oro_entity_config.config_manager'
+            - '%synolia.akeneo.attribute_types_mapping%'
         calls:
             - [setManagerRegistry, ['@doctrine']]
             - [setClassName, ['attribute']]

--- a/Resources/config/parameters.yml
+++ b/Resources/config/parameters.yml
@@ -1,0 +1,13 @@
+parameters:
+  synolia.akeneo.attribute_types_mapping:
+    pim_catalog_identifier: string
+    pim_catalog_text: string
+    pim_catalog_textarea: text
+    pim_catalog_metric: decimal
+    pim_catalog_boolean: boolean
+    pim_catalog_simpleselect: enum
+    pim_catalog_number: decimal
+    pim_catalog_multiselect: multiEnum
+    pim_catalog_date: date
+    pim_catalog_image: image
+    pim_catalog_file: file


### PR DESCRIPTION
The attributes list can be now parametered, in order to accept EE attribute types (PAM assets) and custom types (eg. [custom type](https://docs.akeneo.com/cookbook/ui_customization/create_a_new_field_type.html) or [example range type](https://github.com/akeneo/ExtendedAttributeTypeBundle))